### PR TITLE
Revise April 24 daily scrum notes

### DIFF
--- a/Sprint-Planning/Sprint-3/Daily-Scrums/April-24.md
+++ b/Sprint-Planning/Sprint-3/Daily-Scrums/April-24.md
@@ -22,7 +22,8 @@
 - 
 
 **Anthony Nguyen:**  
-- 
+- Conducted a final audit of the Sprint 3 Acceptance Criteria to ensure all functional requirements for the "Outty" discovery engine were met.
+- Double-checking for any bugs or missing features that are restricting the completion of our User Stories.
 
 **Gilberto Gonzalez:**  
 - Conducted documentation audit and submission prep.
@@ -46,7 +47,8 @@
 - 
 
 **Anthony Nguyen:**  
-- 
+- Report any bugs for each update to the app to fix or to create the missing feature
+- Manage and merge each pull request after reviewing the file changes
 
 **Gilberto Gonzalez:**  
 - Revise and finalize Task 13 (Security & Privacy) unit test D.


### PR DESCRIPTION
Updated daily scrum notes for April 24, including audit tasks and bug reporting responsibilities.